### PR TITLE
Replace NULL with nullptr

### DIFF
--- a/Callback.h
+++ b/Callback.h
@@ -63,7 +63,7 @@ public:
 
                 for (int j = i; j < _nextSlot; ++j)
                     _connections[j] = _connections[j + 1];
-                _connections[_nextSlot] = NULL;
+                _connections[_nextSlot] = nullptr;
             }
         }
     }


### PR DESCRIPTION
The `NULL` macro requires cstddef to be included. Replacing with the `nullptr` keyword from C++11 works without the additional include.